### PR TITLE
Upgrade ingresses to networking.k8s.io/v1

### DIFF
--- a/apps/argoevents/templates/ingresses.yaml
+++ b/apps/argoevents/templates/ingresses.yaml
@@ -1,11 +1,10 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
   {{ if .ssl }}
     cert-manager.io/cluster-issuer: letsencrypt
   {{ end }}
@@ -28,9 +27,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
   {{ if .ssl }}
   tls:

--- a/apps/argoworkflows/templates/ingresses.yaml
+++ b/apps/argoworkflows/templates/ingresses.yaml
@@ -1,11 +1,10 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
   {{ if .ssl }}
     cert-manager.io/cluster-issuer: letsencrypt
   {{ end }}
@@ -28,9 +27,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
   {{ if .ssl }}
   tls:

--- a/apps/betaknesset/templates/ingress.yaml
+++ b/apps/betaknesset/templates/ingress.yaml
@@ -1,24 +1,31 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: betaknesset-elasticsearch-kibana
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   rules:
   - host: betaknesset-elasticsearch.hasadna.org.il
     http:
       paths:
-      - backend:
-          serviceName: betaknesset-elasticsearch-es-http
-          servicePort: 9200
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: betaknesset-elasticsearch-es-http
+            port:
+              number: 9200
   - host: betaknesset-kibana.hasadna.org.il
     http:
       paths:
-      - backend:
-          serviceName: betaknesset-kibana-kb-http
-          servicePort: 5601
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: betaknesset-kibana-kb-http
+            port:
+              number: 5601
   tls:
   - hosts:
     - betaknesset-elasticsearch.hasadna.org.il

--- a/apps/datacity/templates/ingresses.yaml
+++ b/apps/datacity/templates/ingresses.yaml
@@ -1,6 +1,6 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
@@ -12,9 +12,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
 ---
 {{ end }}

--- a/apps/dear-diary/templates/app-ingress.yaml
+++ b/apps/dear-diary/templates/app-ingress.yaml
@@ -1,9 +1,8 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: app
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   rules:
@@ -11,13 +10,19 @@ spec:
     http:
       paths:
       - path: /static
+        pathType: Prefix
         backend:
-          serviceName: nginx
-          servicePort: 80
+          service:
+            name: nginx
+            port:
+              number: 80
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: web
-          servicePort: 80
+          service:
+            name: web
+            port:
+              number: 80
   tls:
   - hosts:
     - {{ .Values.appIngress.host }}

--- a/apps/forum/values.yaml
+++ b/apps/forum/values.yaml
@@ -21,7 +21,7 @@ discourse:
     annotations:
       kubernetes.io/ingress.class: "nginx"
       cert-manager.io/cluster-issuer: letsencrypt
-    apiVersion: extensions/v1beta1
+    apiVersion: networking.k8s.io/v1
     hostname: forum.hasadna.org.il
     tls: true
     # extraTls:

--- a/apps/hasadna-argocd/README.md
+++ b/apps/hasadna-argocd/README.md
@@ -84,22 +84,26 @@ kustomize build apps/hasadna-argocd/manifests | kubectl apply -n argocd -f -
 Deploy ingresses
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-https
   namespace: argocd
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
+    
 spec:
   rules:
   - host: argocd.hasadna.org.il
     http:
       paths:
-      - backend:
-          serviceName: argocd-server
-          servicePort: http
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: argocd-server
+            port:
+              name: http
   tls:
   - hosts:
     - argocd.hasadna.org.il
@@ -107,23 +111,26 @@ spec:
 ```
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: argocd-server-grpc
   namespace: argocd
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/backend-protocol: "GRPC"
 spec:
   rules:
   - host: argocd-grpc.hasadna.org.il
     http:
       paths:
-      - backend:
-          serviceName: argocd-server
-          servicePort: https
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: argocd-server
+            port:
+              name: https
   tls:
   - hosts:
     - argocd-grpc.hasadna.org.il

--- a/apps/hasadna/templates/ingresses.yaml
+++ b/apps/hasadna/templates/ingresses.yaml
@@ -1,11 +1,10 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
   {{ if .ssl }}
     cert-manager.io/cluster-issuer: letsencrypt
   {{ end }}
@@ -23,9 +22,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
   {{ if .ssl }}
   tls:

--- a/apps/leafy/templates/app-ingress.yaml
+++ b/apps/leafy/templates/app-ingress.yaml
@@ -1,9 +1,8 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: app
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   rules:
@@ -11,13 +10,19 @@ spec:
     http:
       paths:
       - path: /static
+        pathType: Prefix
         backend:
-          serviceName: nginx
-          servicePort: 80
+          service:
+            name: nginx
+            port:
+              number: 80
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: web
-          servicePort: 80
+          service:
+            name: web
+            port:
+              number: 80
   tls:
   - hosts:
     - {{ .Values.appIngress.host }}

--- a/apps/odata/templates/nginx-ingress.yaml
+++ b/apps/odata/templates/nginx-ingress.yaml
@@ -1,5 +1,5 @@
 {{ if and .Values.enabled .Values.ingress.enabled }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nginx
@@ -11,8 +11,12 @@ spec:
   - host: {{ . }}
     http:
       paths:
-      - backend:
-          serviceName: nginx
-          servicePort: 80
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: nginx
+            port:
+              number: 80
   {{ end }}
 {{ end }}

--- a/apps/openbus/templates/ingresses.yaml
+++ b/apps/openbus/templates/ingresses.yaml
@@ -1,11 +1,10 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
   {{ if .ssl }}
     cert-manager.io/cluster-issuer: letsencrypt
   {{ end }}
@@ -28,9 +27,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
   {{ if .ssl }}
   tls:

--- a/apps/openlaw/templates/archive-app-ingress.yaml
+++ b/apps/openlaw/templates/archive-app-ingress.yaml
@@ -1,9 +1,8 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: archive-app
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   rules:
@@ -11,13 +10,19 @@ spec:
     http:
       paths:
       - path: /static
+        pathType: Prefix
         backend:
-          serviceName: archive-nginx
-          servicePort: 80
+          service:
+            name: archive-nginx
+            port:
+              number: 80
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: archive-web
-          servicePort: 80
+          service:
+            name: archive-web
+            port:
+              number: 80
   tls:
   - hosts:
     - {{ .Values.archiveAppIngress.host }}

--- a/apps/openpension/deprecated/ingresses.yaml
+++ b/apps/openpension/deprecated/ingresses.yaml
@@ -1,6 +1,6 @@
 {{- if and .Values.enabled .Values.ingresses }}
 {{- range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
@@ -16,9 +16,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{- end }}
   {{- if .tls }}
   tls:

--- a/apps/openpension/templates/ng-app-ingress.yaml
+++ b/apps/openpension/templates/ng-app-ingress.yaml
@@ -1,9 +1,8 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: ng-app
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     cert-manager.io/cluster-issuer: letsencrypt
 spec:
   rules:
@@ -11,13 +10,19 @@ spec:
     http:
       paths:
       - path: /static
+        pathType: Prefix
         backend:
-          serviceName: ng-nginx
-          servicePort: 80
+          service:
+            name: ng-nginx
+            port:
+              number: 80
       - path: /
+        pathType: Prefix
         backend:
-          serviceName: ng-web
-          servicePort: 80
+          service:
+            name: ng-web
+            port:
+              number: 80
   tls:
   - hosts:
     - {{ .Values.ngAppIngress.host }}

--- a/apps/redash/templates/ingresses.yaml
+++ b/apps/redash/templates/ingresses.yaml
@@ -1,11 +1,10 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
   {{ if .ssl }}
     cert-manager.io/cluster-issuer: letsencrypt
   {{ end }}
@@ -23,9 +22,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
   {{ if .ssl }}
   tls:

--- a/apps/reportit/templates/ingresses.yaml
+++ b/apps/reportit/templates/ingresses.yaml
@@ -1,6 +1,6 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
@@ -14,9 +14,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
 ---
 {{ end }}

--- a/apps/resourcesaverproxy/templates/ingresses.yaml
+++ b/apps/resourcesaverproxy/templates/ingresses.yaml
@@ -1,11 +1,10 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
   {{ if .ssl }}
     cert-manager.io/cluster-issuer: letsencrypt
   {{ end }}
@@ -23,9 +22,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
   {{ if .ssl }}
   tls:

--- a/apps/treebase/templates/ingresses.yaml
+++ b/apps/treebase/templates/ingresses.yaml
@@ -1,6 +1,6 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
@@ -12,9 +12,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
 ---
 {{ end }}

--- a/apps/treecatalog/templates/ingresses.yaml
+++ b/apps/treecatalog/templates/ingresses.yaml
@@ -1,6 +1,6 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
@@ -10,9 +10,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
 ---
 {{ end }}

--- a/apps/wordpress/templates/ingresses.yaml
+++ b/apps/wordpress/templates/ingresses.yaml
@@ -1,11 +1,10 @@
 {{ if and .Values.enabled .Values.ingresses }}
 {{ range .Values.ingresses }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ .name }}
   annotations:
-    kubernetes.io/ingress.class: "nginx"
   {{ if .proxy_body_size }}
     nginx.ingress.kubernetes.io/proxy-body-size: {{ .proxy_body_size | quote }}
   {{ end }}
@@ -26,9 +25,13 @@ spec:
   - host: {{ .host }}
     http:
       paths:
-      - backend:
-          serviceName: {{ .serviceName }}
-          servicePort: {{ .servicePort }}
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ .serviceName }}
+            port:
+              number: {{ .servicePort }}
   {{ end }}
   {{ if .ssl }}
   tls:

--- a/docs/kamatera.md
+++ b/docs/kamatera.md
@@ -40,7 +40,7 @@ spec:
 To use, add an ingress, for example (replace NAME, NAMESPACE, HOSTNAME, SERVICENAME):
 
 ```
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   annotations:
@@ -52,9 +52,13 @@ spec:
   - host: HOSTNAME
     http:
       paths:
-      - backend:
-          serviceName: SERVICENAME
-          servicePort: 80
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: SERVICENAME
+            port:
+              number: 80
   tls:
   - hosts:
     - HOSTNAME


### PR DESCRIPTION
## Summary
- migrate all remaining Ingress manifests to `networking.k8s.io/v1`
- update documentation snippets to the new API version

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'benedict')*