### PR TITLE
Update ArgoCD app branches

### DIFF
--- a/apps/hasadna-argocd/templates/application-argo-install.yaml
+++ b/apps/hasadna-argocd/templates/application-argo-install.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: apps/argoworkflows/manifests
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/apps/hasadna-argocd/templates/application-argo.yaml
+++ b/apps/hasadna-argocd/templates/application-argo.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/apps/hasadna-argocd/templates/application-argoevents-install.yaml
+++ b/apps/hasadna-argocd/templates/application-argoevents-install.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: apps/argoevents/manifests
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/apps/hasadna-argocd/templates/application-argoevents.yaml
+++ b/apps/hasadna-argocd/templates/application-argoevents.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-betaknesset.yaml
+++ b/apps/hasadna-argocd/templates/application-betaknesset.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-budgetkey.yaml
+++ b/apps/hasadna-argocd/templates/application-budgetkey.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/OpenBudget/budgetkey-k8s.git
-    targetRevision: master
+    targetRevision: codex/upgrade-ingresses-to-v1
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-datacity.yaml
+++ b/apps/hasadna-argocd/templates/application-datacity.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-dear-diary.yaml
+++ b/apps/hasadna-argocd/templates/application-dear-diary.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-forum.yaml
+++ b/apps/hasadna-argocd/templates/application-forum.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/apps/hasadna-argocd/templates/application-hasadna.yaml
+++ b/apps/hasadna-argocd/templates/application-hasadna.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/apps/hasadna-argocd/templates/application-leafy.yaml
+++ b/apps/hasadna-argocd/templates/application-leafy.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-migdar.yaml
+++ b/apps/hasadna-argocd/templates/application-migdar.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/migdar-k8s.git
-    targetRevision: master
+    targetRevision: codex/upgrade-ingresses-to-v1
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-odata.yaml
+++ b/apps/hasadna-argocd/templates/application-odata.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-oknesset-nginx.yaml
+++ b/apps/hasadna-argocd/templates/application-oknesset-nginx.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/OriHoch/knesset-data-k8s.git
-    targetRevision: master
+    targetRevision: codex/upgrade-ingresses-to-v1-templates
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-oknesset-pipelines.yaml
+++ b/apps/hasadna-argocd/templates/application-oknesset-pipelines.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/OriHoch/knesset-data-k8s.git
-    targetRevision: master
+    targetRevision: codex/upgrade-ingresses-to-v1-templates
   syncPolicy:
     syncOptions:
     - CreateNamespace=true

--- a/apps/hasadna-argocd/templates/application-oknesset-publicdb.yaml
+++ b/apps/hasadna-argocd/templates/application-oknesset-publicdb.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/OriHoch/knesset-data-k8s.git
-    targetRevision: master
+    targetRevision: codex/upgrade-ingresses-to-v1-templates
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-oknesset-site.yaml
+++ b/apps/hasadna-argocd/templates/application-oknesset-site.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/OriHoch/knesset-data-k8s.git
-    targetRevision: master
+    targetRevision: codex/upgrade-ingresses-to-v1-templates
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-oknesset-workflows.yaml
+++ b/apps/hasadna-argocd/templates/application-oknesset-workflows.yaml
@@ -10,7 +10,7 @@ spec:
   source:
     path: apps/workflows
     repoURL: https://github.com/OriHoch/knesset-data-k8s.git
-    targetRevision: master
+    targetRevision: codex/upgrade-ingresses-to-v1-templates
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-openbus.yaml
+++ b/apps/hasadna-argocd/templates/application-openbus.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     #{{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-openlaw.yaml
+++ b/apps/hasadna-argocd/templates/application-openlaw.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-openpension.yaml
+++ b/apps/hasadna-argocd/templates/application-openpension.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-redash.yaml
+++ b/apps/hasadna-argocd/templates/application-redash.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-reportit.yaml
+++ b/apps/hasadna-argocd/templates/application-reportit.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-resourcesaver.yaml
+++ b/apps/hasadna-argocd/templates/application-resourcesaver.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-srm-ckan-production-backups.yaml
+++ b/apps/hasadna-argocd/templates/application-srm-ckan-production-backups.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/srm-devops.git
-    targetRevision: main
+    targetRevision: codex/upgrade-ingresses-to-v1
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-srm-etl-production.yaml
+++ b/apps/hasadna-argocd/templates/application-srm-etl-production.yaml
@@ -15,7 +15,7 @@ spec:
         value: production
       name: uumpa
     repoURL: https://github.com/hasadna/srm-devops.git
-    targetRevision: main
+    targetRevision: codex/upgrade-ingresses-to-v1
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-srm-etl-staging.yaml
+++ b/apps/hasadna-argocd/templates/application-srm-etl-staging.yaml
@@ -15,7 +15,7 @@ spec:
         value: staging
       name: uumpa
     repoURL: https://github.com/hasadna/srm-devops.git
-    targetRevision: main
+    targetRevision: codex/upgrade-ingresses-to-v1
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-srm-site-production.yaml
+++ b/apps/hasadna-argocd/templates/application-srm-site-production.yaml
@@ -15,7 +15,7 @@ spec:
         value: production
       name: uumpa
     repoURL: https://github.com/hasadna/srm-devops.git
-    targetRevision: main
+    targetRevision: codex/upgrade-ingresses-to-v1
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-srm-site-staging.yaml
+++ b/apps/hasadna-argocd/templates/application-srm-site-staging.yaml
@@ -15,7 +15,7 @@ spec:
         value: staging
       name: uumpa
     repoURL: https://github.com/hasadna/srm-devops.git
-    targetRevision: main
+    targetRevision: codex/upgrade-ingresses-to-v1
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-treebase.yaml
+++ b/apps/hasadna-argocd/templates/application-treebase.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-treecatalog.yaml
+++ b/apps/hasadna-argocd/templates/application-treecatalog.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:

--- a/apps/hasadna-argocd/templates/application-wordpress.yaml
+++ b/apps/hasadna-argocd/templates/application-wordpress.yaml
@@ -12,7 +12,7 @@ spec:
     plugin:
       name: uumpa
     repoURL: https://github.com/hasadna/hasadna-k8s.git
-    targetRevision: master
+    targetRevision: rke2-upgrade
   syncPolicy:
     {{ if .Values.allowAutoSync }}
     automated:


### PR DESCRIPTION
## Summary
- point all hasadna-k8s applications to branch `rke2-upgrade`
- use `codex/upgrade-ingresses-to-v1` for srm-devops and migdar-k8s apps
- use `codex/upgrade-ingresses-to-v1-templates` for knesset-data-k8s apps
- use `codex/upgrade-ingresses-to-v1` for budgetkey-k8s apps

## Testing
- `uv pip install --requirement tests/requirements.txt`
- `uv run pytest -q`