### PR TITLE
Switch NFS volumes to PVC

### DIFF
--- a/apps/odata/templates/ckan-deployment.yaml
+++ b/apps/odata/templates/ckan-deployment.yaml
@@ -130,7 +130,10 @@ spec:
         configMap:
           name: ckan
       - name: ckan-data
-        {{ if .Values.hostPath }}
+        {{ if .Values.ckanPersistentVolumeClaimName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.ckanPersistentVolumeClaimName | quote }}
+        {{ else if .Values.hostPath }}
         hostPath:
           path: {{ .Values.hostPath | quote }}
           type: DirectoryOrCreate

--- a/apps/odata/templates/ckan-jobs-deployment.yaml
+++ b/apps/odata/templates/ckan-jobs-deployment.yaml
@@ -91,7 +91,10 @@ spec:
         configMap:
           name: ckan
       - name: ckan-data
-        {{ if .Values.hostPath }}
+        {{ if .Values.ckanJobsPersistentVolumeClaimName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.ckanJobsPersistentVolumeClaimName | quote }}
+        {{ else if .Values.hostPath }}
         hostPath:
           path: {{ .Values.hostPath | quote }}
           type: DirectoryOrCreate

--- a/apps/odata/templates/nginx-deployment.yaml
+++ b/apps/odata/templates/nginx-deployment.yaml
@@ -56,7 +56,10 @@ spec:
         emptyDir: {}
         {{ end }}
       - name: ckan-data
-        {{ if .Values.hostPath }}
+        {{ if .Values.nginxPersistentVolumeClaimName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.nginxPersistentVolumeClaimName | quote }}
+        {{ else if .Values.hostPath }}
         hostPath:
           path: {{ .Values.hostPath | quote }}
           type: DirectoryOrCreate

--- a/apps/odata/templates/pipelines-deployment.yaml
+++ b/apps/odata/templates/pipelines-deployment.yaml
@@ -180,7 +180,10 @@ spec:
         - {mountPath: /var/lib/ckan, name: ckan-data, subPath: ckan}
       volumes:
       - name: ckan-data
-        {{ if .Values.hostPath }}
+        {{ if .Values.pipelinesPersistentVolumeClaimName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.pipelinesPersistentVolumeClaimName | quote }}
+        {{ else if .Values.hostPath }}
         hostPath:
           path: {{ .Values.hostPath | quote }}
           type: DirectoryOrCreate

--- a/apps/odata/values-hasadna.yaml
+++ b/apps/odata/values-hasadna.yaml
@@ -10,6 +10,10 @@ nginxResources: '{"requests": {"cpu": "25m", "memory": "256Mi"}, "limits": {"cpu
 #  ckanDbPersistentDiskName: odata-db
 ckanDataNfsServer: "~iac:hasadna_nfs1_internal_ip~"
 ckanDataNfsPath: "/odata"
+nginxPersistentVolumeClaimName: pipelines
+pipelinesPersistentVolumeClaimName: pipelines
+ckanPersistentVolumeClaimName: ckan
+ckanJobsPersistentVolumeClaimName: ckan-jobs
 ckanSecretName: ckan-secrets-2
 envVarsSecretName: env-vars
 #  dbNfsEnabled: true

--- a/apps/openbus/templates/airflow-scheduler-deployment.yaml
+++ b/apps/openbus/templates/airflow-scheduler-deployment.yaml
@@ -65,14 +65,29 @@ spec:
               mountPath: /var/gtfs-storage
       volumes:
         - name: airflow-home
+          {{ if .Values.airflowScheduler.persistentVolumeClaimName }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.airflowScheduler.persistentVolumeClaimName | quote }}
+          {{ else }}
           nfs:
             server: {{ .Values.nfsServer | quote }}
             path: {{ .Values.airflowHomeNfsPath | quote }}
+          {{ end }}
         - name: sirirequester
+          {{ if .Values.airflowScheduler.persistentVolumeClaimName }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.airflowScheduler.persistentVolumeClaimName | quote }}
+          {{ else }}
           nfs:
             server: {{ .Values.nfsServer | quote }}
             path: {{ .Values.siriRequesterNfsPath | quote }}
+          {{ end }}
         - name: gtfs
+          {{ if .Values.airflowScheduler.persistentVolumeClaimName }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.airflowScheduler.persistentVolumeClaimName | quote }}
+          {{ else }}
           nfs:
             server: {{ .Values.nfsServer | quote }}
             path: {{ .Values.gtfsNfsPath | quote }}
+          {{ end }}

--- a/apps/openbus/templates/gtfs-nginx-deployment.yaml
+++ b/apps/openbus/templates/gtfs-nginx-deployment.yaml
@@ -32,6 +32,11 @@ spec:
         configMap:
           name: gtfs-nginx
       - name: gtfs
+        {{ if .Values.gtfsNginxPersistentVolumeClaimName }}
+        persistentVolumeClaim:
+          claimName: {{ .Values.gtfsNginxPersistentVolumeClaimName | quote }}
+        {{ else }}
         nfs:
           server: {{ .Values.nfsServer | quote }}
           path: {{ .Values.gtfsNfsPath | quote }}
+        {{ end }}

--- a/apps/openbus/values-hasadna.yaml
+++ b/apps/openbus/values-hasadna.yaml
@@ -35,6 +35,7 @@ airflowWebserver:
   resources: '{"requests": {"cpu": "100m", "memory": "500Mi"}, "limits": {"memory": "1000Mi"}}'
 airflowScheduler:
   resources: '{"requests": {"cpu": "2000m", "memory": "12000Mi"}, "limits": {"memory": "16000Mi"}}'
+  persistentVolumeClaimName: airflow-scheduler
 
 airflow:
   enableEmails: true
@@ -50,6 +51,7 @@ strideApiResources: {"requests": {"cpu": "1000m", "memory": "1000Mi"}, "limits":
 backendResources: {"requests": {"cpu": "50m", "memory": "100Mi"}, "limits": {"memory": "200Mi"}}
 
 gtfsNfsPath: "/openbus/gtfs"
+gtfsNginxPersistentVolumeClaimName: gtfs-nginx
 gtfsNginxResources: {"requests": {"cpu": "50m", "memory": "50Mi"}, "limits": {"memory": "200Mi"}}
 
 legacy:


### PR DESCRIPTION
## Summary
- switch odata nginx/pipelines/ckan/ckan-jobs to use a PVC if provided
- add PVC names in odata values to select the PVC option
- allow gtfs-nginx and airflow-scheduler to mount a PVC
- include new PVC names in openbus values

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'benedict')*