### PR TITLE
mapathataf: add manage super-admin console deployment

### DIFF
--- a/apps/mapathataf/templates/manage-deployment.yaml
+++ b/apps/mapathataf/templates/manage-deployment.yaml
@@ -1,0 +1,22 @@
+{{ if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: manage
+spec:
+  selector:
+    matchLabels:
+      app: manage
+  replicas: 1
+  revisionHistoryLimit: 2
+  template:
+    metadata:
+      labels:
+        app: manage
+    spec:
+      terminationGracePeriodSeconds: 2
+      containers:
+      - name: manage
+        image: {{ .Values.manageImage | default "ghcr.io/whiletrue-industries/mapathataf-manage" | quote }}
+        resources: {"requests": {"cpu": "25m", "memory": "128Mi"}, "limits": {"memory": "512Mi"}}
+{{ end }}

--- a/apps/mapathataf/templates/manage-service.yaml
+++ b/apps/mapathataf/templates/manage-service.yaml
@@ -1,0 +1,12 @@
+{{ if .Values.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: manage
+spec:
+  selector:
+    app: manage
+  ports:
+  - name: "4000"
+    port: 4000
+{{ end }}

--- a/apps/mapathataf/values-hasadna.yaml
+++ b/apps/mapathataf/values-hasadna.yaml
@@ -15,6 +15,11 @@ ingresses:
       - host: admin.tafmap.org.il
         serviceName: admin
         servicePort: 4000
+  - name: manage
+    rules:
+      - host: manage.tafmap.org.il
+        serviceName: manage
+        servicePort: 4000
 vertical_pod_autoscalers:
 - apiVersion: apps/v1
   kind: deployment


### PR DESCRIPTION
## Summary

Adds the fourth mapathataf SSR frontend, the super-admin console at **manage.tafmap.org.il**:

- `manage-deployment.yaml` + `manage-service.yaml` — direct copies of the admin ones (port 4000, same resources), image from `.Values.manageImage`.
- `values-hasadna.yaml` — ingress entry for `manage.tafmap.org.il`.

**Merge order**: whiletrue-industries/mapathataf#6 should merge first — its CI pushes `ghcr.io/whiletrue-industries/mapathataf-manage` and writes `manageImage` into `values-hasadna-auto-updated.yaml`; otherwise the Deployment falls back to the untagged default image ref.

Also needs (outside this repo): a DNS record for `manage.tafmap.org.il` pointing at the same edge as the other three hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012gBRcd34kBspfvQ5cQNyFw